### PR TITLE
feat(editor): add deletion of selected SVG nodes

### DIFF
--- a/src/components/applets/AppletLayers.vue
+++ b/src/components/applets/AppletLayers.vue
@@ -13,14 +13,29 @@
 
         <span>{{ prop.node.id }}</span>
         <q-btn
-          v-if="prop.node.id !== 'svg-root' && (!prop.node.children || prop.node.children.length === 0)"
+          v-if="prop.node.id !== 'svg-root' && prop.node.tagName !== 'svg'"
           dense
           flat
           round
-          icon="mdi-delete"
+          icon="eva-more-vertical"
           class="q-ml-auto"
-          @click.stop="deleteNode(prop.node.id)"
-        />
+          :disable="prop.node.id === 'svg-root'"
+        >
+          <q-popup-proxy
+            anchor="bottom right"
+            self="top left"
+            :offset="[0, 4]"
+          >
+            <q-list style="min-width: 100px">
+              <q-item v-if="prop.node.id !== 'svg-root'" clickable @click="() => deleteNode(prop.node.id)">
+                <q-item-section avatar>
+                  <q-icon name="eva-trash-2-outline" />
+                </q-item-section>
+                <q-item-section>Delete</q-item-section>
+              </q-item>
+            </q-list>
+          </q-popup-proxy>
+        </q-btn>
       </template>
     </q-tree>
   </LayoutDrawerApplet>
@@ -30,7 +45,7 @@
 import { computed, ref, watch } from 'vue'
 import LayoutDrawerApplet from 'components/layout/LayoutDrawerApplet.vue'
 import { useEditorStore } from 'src/stores/editor-store.js'
-import { QBtn } from 'quasar'
+import { QBtn, QPopupProxy, QItem, QItemSection, QList, QIcon } from 'quasar'
 
 const editorStore = useEditorStore()
 
@@ -55,7 +70,6 @@ function onTreeSelectionChange(nodeId) {
 }
 
 const deleteNode = (id) => {
-  if (id === 'svg-root') return
   editorStore.setSelectionById(id)
   editorStore.deleteSelected()
 }

--- a/src/components/applets/AppletLayers.vue
+++ b/src/components/applets/AppletLayers.vue
@@ -12,6 +12,15 @@
         <q-icon :name="ICONS[prop.node.tagName]" class="q-mr-sm" />
 
         <span>{{ prop.node.id }}</span>
+        <q-btn
+          v-if="prop.node.id !== 'svg-root' && (!prop.node.children || prop.node.children.length === 0)"
+          dense
+          flat
+          round
+          icon="mdi-delete"
+          class="q-ml-auto"
+          @click.stop="deleteNode(prop.node.id)"
+        />
       </template>
     </q-tree>
   </LayoutDrawerApplet>
@@ -21,6 +30,7 @@
 import { computed, ref, watch } from 'vue'
 import LayoutDrawerApplet from 'components/layout/LayoutDrawerApplet.vue'
 import { useEditorStore } from 'src/stores/editor-store.js'
+import { QBtn } from 'quasar'
 
 const editorStore = useEditorStore()
 
@@ -42,6 +52,12 @@ function onTreeSelectionChange(nodeId) {
   if (nodeId !== editorStore.selectedId) {
     editorStore.setSelectionById(nodeId)
   }
+}
+
+const deleteNode = (id) => {
+  if (id === 'svg-root') return
+  editorStore.setSelectionById(id)
+  editorStore.deleteSelected()
 }
 
 const ICONS = {

--- a/src/components/editor/EditorCanvas.vue
+++ b/src/components/editor/EditorCanvas.vue
@@ -332,6 +332,9 @@ function onKeyDown(evt) {
   if (evt.code === 'Space' && !spacePressed.value) {
     evt.preventDefault()
     spacePressed.value = true
+  } else if (evt.key === 'Delete' && store.selectedId) {
+    evt.preventDefault()
+    store.deleteSelected()
   }
 }
 

--- a/src/stores/editor-store.js
+++ b/src/stores/editor-store.js
@@ -15,7 +15,7 @@ export const useEditorStore = defineStore('editor', {
     _idCounter: 1,
     undoStack: [],
     redoStack: [],
-    
+
     // Settings
     snapEnabled: false,
     snapSize: 10,
@@ -482,7 +482,6 @@ export const useEditorStore = defineStore('editor', {
       const before = this.xml
       const doc = new DOMParser().parseFromString(this.xml, 'image/svg+xml')
       const el = doc.getElementById(this.selectedId)
-      if (!el || el === doc.documentElement) return // Don't delete root SVG
       const parent = el.parentNode
       parent.removeChild(el)
       this.xml = new XMLSerializer().serializeToString(doc.documentElement)

--- a/src/stores/editor-store.js
+++ b/src/stores/editor-store.js
@@ -482,7 +482,10 @@ export const useEditorStore = defineStore('editor', {
       const before = this.xml
       const doc = new DOMParser().parseFromString(this.xml, 'image/svg+xml')
       const el = doc.getElementById(this.selectedId)
+      if (!el) return
+      if (el === doc.documentElement) return // Prevent deleting root SVG
       const parent = el.parentNode
+      if (!parent) return
       parent.removeChild(el)
       this.xml = new XMLSerializer().serializeToString(doc.documentElement)
       this.json = this._updateJsonFromXml()

--- a/src/stores/editor-store.js
+++ b/src/stores/editor-store.js
@@ -476,6 +476,21 @@ export const useEditorStore = defineStore('editor', {
       const svg = doc.documentElement
       this.xml = new XMLSerializer().serializeToString(svg)
     },
+
+    deleteSelected() {
+      if (!this.selectedId) return
+      const before = this.xml
+      const doc = new DOMParser().parseFromString(this.xml, 'image/svg+xml')
+      const el = doc.getElementById(this.selectedId)
+      if (!el || el === doc.documentElement) return // Don't delete root SVG
+      const parent = el.parentNode
+      parent.removeChild(el)
+      this.xml = new XMLSerializer().serializeToString(doc.documentElement)
+      this.json = this._updateJsonFromXml()
+      this.clearSelection()
+      this.undoStack.push(before)
+      this.redoStack = []
+    },
     // Grouping
     groupSelected() {
       if (!this.selectedId) return null


### PR DESCRIPTION
- Introduce delete button for leaf nodes in AppletLayers tree (excludes root)
- Handle Delete key press in EditorCanvas to remove selected elements
- Implement deleteSelected action in editor store with XML parsing, undo support, and JSON update

Fixes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete non-root elements directly from the layers panel via a new context action.
* **Keyboard & Shortcuts**
  * Press Delete to remove the currently selected element; default browser behavior is prevented.
* **Improvements**
  * Deletions are recorded in undo/redo history and clear selection after removal.
* **UI**
  * Added a conditional “more” button in the layers header to access delete actions for eligible nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->