### PR TITLE
feat(editor): Add theme toggle

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,5 +3,14 @@
 </template>
 
 <script setup>
-//
+import { useEditorStore } from 'stores/editor-store.js'
+import { effect } from 'vue'
+import { useQuasar } from 'quasar'
+
+const editorStore = useEditorStore()
+const $q = useQuasar()
+
+effect(() => {
+  $q.dark.set(editorStore.darkMode)
+})
 </script>

--- a/src/components/editor/EditorCanvas.vue
+++ b/src/components/editor/EditorCanvas.vue
@@ -425,6 +425,12 @@ onUnmounted(() => {
     10px 10px;
 }
 
+.body--dark {
+  .canvas-scroll-area {
+    background: #23272a;
+  }
+}
+
 .canvas-scroll-area:active {
   cursor: grabbing;
 }

--- a/src/layouts/EditorLayout.vue
+++ b/src/layouts/EditorLayout.vue
@@ -6,6 +6,13 @@
 
         <LayoutButton
           :active="editorStore.sidebarLeftOpen"
+          icon="eva-moon-outline"
+          data-test="toolbar-toggle-darkMode"
+          @click="editorStore.toggleDarkMode"
+        />
+
+        <LayoutButton
+          :active="editorStore.sidebarLeftOpen"
           icon="eva-arrowhead-left-outline"
           data-test="toolbar-toggle-left"
           @click="editorStore.toggleSidebarLeft"

--- a/src/stores/editor-store.js
+++ b/src/stores/editor-store.js
@@ -6,6 +6,7 @@ export const useEditorStore = defineStore('editor', {
     sidebarLeftOpen: false,
     sidebarRightOpen: false,
     sidebarBottomOpen: false,
+    darkMode: false,
 
     xml: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"></svg>',
     json: { id: 'svg-root', tagName: 'svg', children: [] }, // Initialize with basic structure
@@ -15,7 +16,7 @@ export const useEditorStore = defineStore('editor', {
     _idCounter: 1,
     undoStack: [],
     redoStack: [],
-    
+
     // Settings
     snapEnabled: false,
     snapSize: 10,
@@ -35,6 +36,9 @@ export const useEditorStore = defineStore('editor', {
     },
     toggleSidebarBottom() {
       this.sidebarBottomOpen = !this.sidebarBottomOpen
+    },
+    toggleDarkMode() {
+      this.darkMode = !this.darkMode;
     },
 
     // Settings


### PR DESCRIPTION
Implements #22 
- adds a button to the EditorLayout to toggle between dark mode and normal mode
- adds an effect to app.vue to listen to the state of the darkMode toggle in the editorStore
- adds a property and method to the editorStore to store the darkMode state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a dark mode for the editor.
  - Introduced a toolbar button to toggle dark mode instantly.
  - App theme now updates dynamically to reflect the selected mode.

- Style
  - Enhanced dark theme visuals with a darker canvas background for improved contrast and comfort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->